### PR TITLE
Fix export of `lib/extensions`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 export { cache } from './lib/cache'
 export { config } from './lib/config'
-export { extensions } from './lib/extensions'
+export { default as extensions } from './lib/extensions'
 export { extract } from './lib/extract'
 export { fetch } from './lib/fetch'
 export { install } from './lib/install'


### PR DESCRIPTION
Unlike the other `lib/` submodules, `lib/extensions` exports as `default`.

Due to this, `require('lnd-binary').extensions` was undefined.

Now it works as expected.